### PR TITLE
HARVEY2-501 Fix by always sending complete parameters service request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # param_ext version history
 
+## 0.0.03
+
+- Fix issue with empty parameters
+
+## 0.0.2
+
+- Alphabetize nodes
+
 ## 0.0.1
 
 - Alpha testing

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Interact with Parameters in ROS2",
   "publisher": "Daniel Clapp",
   "homepage": "https://github.com/danclapp4/ros2-parameter-extension",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "license": "MIT",
   "main": "./dist/extension.js",
   "keywords": [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { ExtensionContext } from "@foxglove/studio";
 import { initParamsPanel } from "./ExamplePanel";
 
 export function activate(extensionContext: ExtensionContext) {
-  extensionContext.registerPanel({ name: "Custom Parameters Extenstion", initPanel: initParamsPanel });
+  extensionContext.registerPanel({ name: "Custom Parameters Extension", initPanel: initParamsPanel });
 }
 
 


### PR DESCRIPTION
Alternative to: https://github.com/nobleo/ros2-parameter-extension/pull/1

This implements the suggestion from here: https://github.com/foxglove/ros-foxglove-bridge/issues/333 where a `/set_parameters service` request should always contain the complete request, not only the changed parameter.

If not done this way, a request with multiple parameters will crash the targeted node.